### PR TITLE
Adding optional parameter

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -161,7 +161,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			}
 		}
 
-		function comment( $comment_id, $comment_approved ) {
+		function comment( $comment_id, $comment_approved = false ) {
 			$comment = get_comment( $comment_id );
 			if ( property_exists( $comment, 'comment_post_ID' ) ) {
 				$post_url = get_permalink( $comment->comment_post_ID );


### PR DESCRIPTION
PHP was throwing a warning, I believe, because the second argument was required, but not (always?) passed in. My solution on a friend's site was to just add `= false` there, but the argument is not used anyway, so I'm not sure what good it is doing in there exactly to begin with.