### PR TITLE
test for is_user_logged_in() before calling

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -712,7 +712,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				$return = false;
 			} elseif ( 'private' === get_post_status() ) {
 				$return = false;
-			} elseif ( is_404() ) {
+			} elseif ( function_exists( 'is_404' ) && is_404() ) {
 				$return = false;
 			} elseif ( is_admin() ) {
 				$return = false;
@@ -724,7 +724,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				$return = false;
 			} elseif ( isset( $_POST ) && ! empty( $_POST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$return = false;
-			} elseif ( is_feed() ) {
+			} elseif ( function_exists( 'is_feed' ) && is_feed() ) {
 				$return = false;
 			}
 

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -718,7 +718,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				$return = false;
 			} elseif ( false === get_option( 'permalink_structure' ) ) {
 				$return = false;
-			} elseif ( is_user_logged_in() ) {
+			} elseif ( function_exists( 'is_user_logged_in' ) && is_user_logged_in() ) {
 				$return = false;
 			} elseif ( isset( $_GET ) && ! empty( $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$return = false;

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -712,7 +712,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				$return = false;
 			} elseif ( 'private' === get_post_status() ) {
 				$return = false;
-			} elseif ( function_exists( 'is_404' ) && is_404() ) {
+			} elseif ( is_404() ) {
 				$return = false;
 			} elseif ( is_admin() ) {
 				$return = false;
@@ -724,7 +724,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				$return = false;
 			} elseif ( isset( $_POST ) && ! empty( $_POST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$return = false;
-			} elseif ( function_exists( 'is_feed' ) && is_feed() ) {
+			} elseif ( is_feed() ) {
 				$return = false;
 			}
 


### PR DESCRIPTION
My debug.log is littered with PHP notices reporting that `is_404` and `is_feed` are being called incorrectly. I have traced this back to this file.

> [28-Mar-2019 22:17:21 UTC] PHP Notice is_404 was called incorrectly. Conditional query tags do not work before the query is run. Before then, they always return false. Please see Debugging in WordPress for more information. (This message was added in version 3.1.0.) in /home4/thefrage/public_html/thefragens.com/wp-includes/functions.php on line 4667
> [28-Mar-2019 22:17:21 UTC] PHP Notice is_feed was called incorrectly. Conditional query tags do not work before the query is run. Before then, they always return false. Please see Debugging in WordPress for more information. (This message was added in version 3.1.0.) in /home4/thefrage/public_html/thefragens.com/wp-includes/functions.php on line 4667

This PR should fix those issues.

Ping @MikeHansenMe 