### PR TITLE
Make purge requests non-blocking

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -558,6 +558,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			$args = array(
 				'method'     => 'PURGE',
 				'timeout'    => '5',
+				'blocking'   => false,
 				'sslverify'  => false,
 				'headers'    => array(
 					'host' => $domain,


### PR DESCRIPTION
Standard outbound cache purge requests are currently set as blocking requests, but we don't really need to wait for them. This simply switches them to non-blocking. 