### PR TITLE
Force got_rewrite to true for WP CLI requests

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -118,6 +118,8 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 
 			add_filter( 'pre_update_option_mm_cache_settings', array( $this, 'cache_type_change' ), 10, 2 );
 			add_filter( 'pre_update_option_endurance_cache_level', array( $this, 'cache_level_change' ), 10, 2 );
+
+			add_filter( 'got_rewrite', array( $this, 'force_rewrite' ) );
 		}
 
 		/**
@@ -1148,6 +1150,24 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			}
 
 			return $checked_data;
+		}
+
+		/**
+		 * Filter to force got_mod_rewrite() to true
+		 *
+		 * On CLI requests, mod_rewrite is unavailable, so it fails to update
+		 * the .htaccess file when save_mod_rewrite_rules() is called. This
+		 * forces that to be true so updates from WP CLI work.
+		 *
+		 * @param bool $got_rewrite Value of apache_mod_loaded('mod_rewrite')
+		 *
+		 * @return bool true for WP CLI requests
+		 */
+		public function force_rewrite( $got_rewrite ) {
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				return true;
+			}
+			return $got_rewrite;
 		}
 	}
 


### PR DESCRIPTION
When making an option update via WP CLI, `mod_rewrite` is technically not available. This causes `got_mod_rewrite()` to return `false`, preventing `save_mod_rewrite_rules()` from completing. 

Because of this, `.htaccess` isn't getting updated when the cache level setting is changed via WP CLI. 

This fixes this issue by adding a filter which forces `got_mod_rewrite()` to true for WP CLI commands. 