### PR TITLE
Prevent AJAX short circuit

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -65,9 +65,6 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 */
 		public function __construct() {
 
-			if ( defined( 'DOING_AJAX' ) ) {
-				return;
-			}
 			if ( isset( $_GET['doing_wp_cron'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				return;
 			}
@@ -720,7 +717,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				$return = false;
 			} elseif ( false === get_option( 'permalink_structure' ) ) {
 				$return = false;
-			} elseif ( function_exists('is_user_logged_in') && is_user_logged_in() ) {
+			} elseif ( function_exists( 'is_user_logged_in' ) && is_user_logged_in() ) {
 				$return = false;
 			} elseif ( isset( $_GET ) && ! empty( $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$return = false;

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -709,6 +709,8 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 
 			if ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE === true ) {
 				$return = false;
+			} elseif ( defined( 'DOING_AJAX' ) ) {
+				$return = false;
 			} elseif ( 'private' === get_post_status() ) {
 				$return = false;
 			} elseif ( isset( $wp_query ) && is_404() ) {


### PR DESCRIPTION
Currently the `Endurance_Page_Cache` class returns immediately on in `__construct()` when `DOING_AJAX` is defined. This prevents the `.htaccess` file from being updated through AJAX requests, including the Bluehost > Performance page in the WordPress admin because the proper action/filter hooks are never registered. 

This simply moves this check to the `is_cachable()` (spelling is wrong, btw) function. This will make sure that any ajax requests aren't considered cachable, but ajax calls can still be used for cache purging or setting change purposes. 