### PR TITLE
Fix single purges on save_post hook

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -385,7 +385,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				// Purge post URL when post is updated.
 				$permalink = get_permalink( $post_id );
 				if ( $permalink ) {
-					$this->purge_single( $post_id );
+					$this->purge_single( $permalink );
 				}
 
 				// Purge taxonomy term URLs for related terms.
@@ -1175,7 +1175,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		public function update( $checked_data ) {
 
 			$muplugins_details = get_transient( 'mojo_plugin_assets' );
-			
+
 			if ( ! $muplugins_details ) {
 				$muplugins_details = wp_remote_get( 'https://api.mojomarketplace.com/mojo-plugin-assets/json/mu-plugins.json' );
 				if ( ! is_wp_error( $muplugins_details )  ) {


### PR DESCRIPTION
In #61 we [accidentally changed the call](https://github.com/bluehost/endurance-page-cache/commit/e50697c93f48df7024e7144293102b41e6e5d91d#diff-d49d13a0e6fabdd38480bc354b8f2127R389) to `purge_single()` to use the post ID instead of the permalink. 

This causes some invalid purge requests that will never work.
![image](https://user-images.githubusercontent.com/4267290/56421066-c0146f00-626e-11e9-80fa-67449ec46dda.png)
