### PR TITLE
Fix the cache level settings dropdown

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -188,7 +188,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 * @param array $args Settings
 		 */
 		public function output_cache_settings( $args ) {
-			$cache_level = get_option( $args['field'], 2 );
+			$cache_level = absint( get_option( $args['field'], 2 ) );
 			echo '<select name="' . esc_attr( $args['field'] ) . '">';
 			$cache_levels = array(
 				0 => 'Off',


### PR DESCRIPTION
The cache level setting dropdown under Settings > General is not being preset to the currently assigned cache value. This is happening because it comes out of the database as a string, but it's doing a strict comparison to an integer. 

This PR just forces it to be an integer to allow the strict comparison. 