### PR TITLE
UDEV Cache API Purging with Buffer

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -793,6 +793,9 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 					$image_urls = $this->extract_image_urls( $content );
 					foreach ( $image_urls as $image_url ) {
 						$this->purge_cdn_single( wp_parse_url( $image_url, PHP_URL_PATH ) . '$' );
+						if ( ! empty( $this->udev_purge_buffer ) ) {
+							$this->udev_purge_buffer[] = wp_parse_url( $image_url, PHP_URL_PATH );
+						}
 					}
 				}
 			}

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1359,7 +1359,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			$request = array( 'hosts' => $hosts );
 
 			if ( ! empty( $resources ) ) {
-				$request['assets'] = $resources;
+				$request['assets'] = array_unique( array_filter( $resources ) );
 			}
 
 			return wp_json_encode( $request );

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1341,13 +1341,11 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 * @return void
 		 */
 		protected function udev_cache_api_uri( $services ) {
-			$full = trailingslashit( static::$udev_api_root )
+			return trailingslashit( static::$udev_api_root )
 					. trailingslashit( static::$udev_api_version )
 					. static::$udev_api_endpoint
 					. '?' 
 					. http_build_query( $services );
-			// error_log( var_export( $full, true ) );
-			return $full;
 		}
 
 		/**
@@ -1363,8 +1361,6 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			if ( ! empty( $resources ) ) {
 				$request['assets'] = $resources;
 			}
-
-			// error_log( var_export( wp_json_encode( $request ), true ) );
 
 			return wp_json_encode( $request );
 		}


### PR DESCRIPTION
This PR adds:
* Methods for creating HTTP request to UDEV Cache Purge API
* A buffer array in which all resources are stored until request is made on shutdown

Still needed:
* ~Valid check for site active on Cloudflare (db option check, api request, etc)~