### PR TITLE
Address array reindexing

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Endurance Page Cache
  * Description: This cache plugin is primarily for cache purging of the additional layers of cache that may be available on your hosting account.
- * Version: 1.8
+ * Version: 1.9
  * Author: Mike Hansen
  * Author URI: https://www.mikehansen.me/
  * License: GPLv2 or later
@@ -27,7 +27,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'EPC_VERSION', 1.8 );
+define( 'EPC_VERSION', 1.9 );
 
 if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1459,7 +1459,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			$request = array( 'hosts' => $hosts );
 
 			if ( ! empty( $resources ) ) {
-				$request['assets'] = array_unique( array_filter( $resources ) );
+				$request['assets'] = array_values( array_unique( array_filter( $resources ) ) );
 			}
 
 			return wp_json_encode( $request );


### PR DESCRIPTION
Because we're using `array_unique()` and `array_filter()` the numerical index is thrown off and when it's written to JSON, the keys get written.

By running through `array_values()` this re-indexes the array starting at 0 and going up sequentially such that when it gets written to JSON, only the values are used.