### PR TITLE
Check if file is_writable before putting contents.

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1368,7 +1368,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 					if ( isset( $info['constant'] ) && defined( $info['constant'] ) ) {
 						if ( version_compare( $info['version'], constant( $info['constant'] ), '>' ) ) {
 							$file = wp_remote_get( $info['source'] );
-							if ( ! is_wp_error( $file ) && isset( $file['body'] ) && strpos( $file['body'], $info['constant'] ) ) {
+							if ( ! is_wp_error( $file ) && isset( $file['body'] ) && strpos( $file['body'], $info['constant'] ) && is_writable( WP_CONTENT_DIR . $info['destination'] ) ) {
 								file_put_contents( WP_CONTENT_DIR . $info['destination'], $file['body'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 							}
 						}


### PR DESCRIPTION
## Proposed changes

Adds check that the file is writable before putting contents in the file. This allows the file to be symlinked, hard linked, or tighter perms when managed. Systems team has tested and confirmed this is working on the new platform.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
