### PR TITLE
Cloudflare restrict by enabled option & triggers

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1038,6 +1038,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			if ( $this->cache_level > 3 ) {
 				$this->cache_level = 3;
 			}
+
 			$base      = wp_parse_url( trailingslashit( get_option( 'home' ) ), PHP_URL_PATH );
 			$cache_url = $base . str_replace( get_option( 'home' ), '', WP_CONTENT_URL . '/endurance-page-cache' );
 			$cache_url = str_replace( '//', '/', $cache_url );

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -100,6 +100,13 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		public $should_update_throttled_items = false;
 
 		/**
+		 * Record keeping for which triggers have fired
+		 *
+		 * @var array
+		 */
+		public $triggers = [];
+
+		/**
 		 * UDEV Purge Buffer
 		 *
 		 * This parameter determines whether to hit the UDEV Cache Purge API.
@@ -475,7 +482,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				}
 			}
 
-			$this->purge_trigger = 'option_update_' . $option;
+			$this->add_trigger( 'option_update_' . $option );
 			$this->purge_all();
 
 			return true;
@@ -777,7 +784,9 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 
 			$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
-			$trigger = ( isset( $this->purge_trigger ) && ! is_null( $this->purge_trigger ) ) ? $this->purge_trigger : current_action();
+			if ( empty( $this->triggers ) ) {
+				$this->add_trigger( current_action() );
+			}
 
 			$args = array(
 				'method'     => 'PURGE',
@@ -787,7 +796,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				'headers'    => array(
 					'host' => $domain,
 				),
-				'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url() . '; EPC/v' . EPC_VERSION . '/' . $trigger,
+				'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url() . '; EPC/v' . EPC_VERSION . '/' . $this->get_trigger(),
 			);
 			wp_remote_request( $this->get_purge_request_url( $uri, 'http' ), $args );
 			wp_remote_request( $this->get_purge_request_url( $uri, 'https' ), $args );
@@ -1193,10 +1202,10 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			if ( ( isset( $_GET['epc_purge_all'] ) || isset( $_GET['epc_purge_single'] ) ) && is_user_logged_in() && current_user_can( 'manage_options' ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$this->force_purge = true;
 				if ( isset( $_GET['epc_purge_all'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-					$this->purge_trigger = 'toolbar_manual_all';
+					$this->add_trigger( 'toolbar_manual_all' );
 					$this->purge_all();
 				} else {
-					$this->purge_trigger = 'toolbar_manual_single';
+					$this->add_trigger( 'toolbar_manual_single' );
 					$this->purge_single( $this->get_current_single_purge_url() );
 				}
 				header( 'Location: ' . remove_query_arg( array( 'epc_purge_single', 'epc_purge_all' ) ) );
@@ -1429,6 +1438,41 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		}
 
 		/**
+		 * Add trigger for record keeping.
+		 *
+		 * @param string $trigger
+		 *
+		 * @return void
+		 */
+		protected function add_trigger( $trigger ) {
+			$this->triggers[] = $trigger;
+		}
+
+		/**
+		 * Retrieves the most recent trigger
+		 *
+		 * @return string of the most recent trigger from the collection
+		 */
+		protected function get_trigger() {
+			return end( $this->triggers );
+		}
+
+		/**
+		 * Retrieves all the triggers to send with bundled requests
+		 *
+		 * @param string $include_duplicates Determines if the array should be unique
+		 *
+		 * @return array
+		 */
+		protected function get_triggers( $include_duplicates = false ) {
+			if ( ! $include_duplicates ) {
+				return array_values( array_unique( $this->triggers ) );
+			} else {
+				return $this->triggers;
+			}
+		}
+
+		/**
 		 * Primary function for the UDEV Purge Cache API. Makes non-blocking request for current install cache purges.
 		 *
 		 * Calling this method with *no* parameters triggers a full cache wipe for the domain.
@@ -1502,6 +1546,8 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			if ( ! empty( $resources ) ) {
 				$request['assets'] = array_values( array_unique( array_filter( $resources ) ) );
 			}
+
+			$request['triggers'] = $this->triggers;
 
 			return wp_json_encode( $request );
 		}

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1445,6 +1445,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 
 			if ( $this->use_file_cache()
 				|| ! in_array( $brand, $this->cloudflare_support, true )
+				|| false === $this->cloudflare_enabled
 			) {
 				return;
 			}

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1499,14 +1499,12 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 * Note that $this->purge_all() presets an empty array, which denotes a full domain purge.
 		 *
 		 * @param string $uri URI to add to udev purge buffer
-		 * @return true|void
+		 * @return void
 		 */
 		protected function udev_cache_populate_buffer( $uri ) {
-			if ( is_array( $this->udev_purge_buffer ) && empty( $this->udev_purge_buffer ) ) {
-				return true; // purge all
-			} elseif ( is_array( $this->udev_purge_buffer ) ) {
+			if ( is_array( $this->udev_purge_buffer ) ) {
 				$this->udev_purge_buffer[] = wp_parse_url( $uri, PHP_URL_PATH );
-			} else {
+			} elseif ( false === $this->udev_purge_buffer ) {
 				$this->udev_purge_buffer = array( wp_parse_url( $uri, PHP_URL_PATH ) );
 			}
 		}

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1031,8 +1031,12 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 * @return string
 		 */
 		public function htaccess_contents_rewrites( $rules ) {
-			if ( false === is_numeric( $this->cache_level ) || $this->cache_level > 3 ) {
+			if ( false === is_numeric( $this->cache_level ) ) {
 				$this->cache_level = 2;
+			}
+
+			if ( $this->cache_level > 3 ) {
+				$this->cache_level = 3;
 			}
 			$base      = wp_parse_url( trailingslashit( get_option( 'home' ) ), PHP_URL_PATH );
 			$cache_url = $base . str_replace( get_option( 'home' ), '', WP_CONTENT_URL . '/endurance-page-cache' );

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -104,7 +104,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 *
 		 * @var array
 		 */
-		public $triggers = [];
+		public $triggers = array();
 
 		/**
 		 * UDEV Purge Buffer
@@ -169,6 +169,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			$this->cache_dir   = WP_CONTENT_DIR . '/endurance-page-cache';
 
 			$cloudflare_state  = get_option( 'endurance_cloudflare_enabled', false );
+
 			$this->cloudflare_enabled = (bool) $cloudflare_state;
 			$this->cloudflare_tier    = ( 'premium' === $cloudflare_state ) ? 'premium' : 'basic';
 
@@ -1440,7 +1441,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		/**
 		 * Add trigger for record keeping.
 		 *
-		 * @param string $trigger
+		 * @param string $trigger Typically an action but can be manually set in the event of a force purge.
 		 *
 		 * @return void
 		 */

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -71,7 +71,6 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 */
 		public $cloudflare_tier = 'basic';
 
-
 		/**
 		 * Brands supporting cloudflare (from mm_brand option).
 		 *

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1513,7 +1513,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 * @return void
 		 */
 		protected function udev_cache_populate_buffer( $uri ) {
-			if ( is_array( $this->udev_purge_buffer ) ) {
+			if ( is_array( $this->udev_purge_buffer ) && ! empty( $this->udev_purge_buffer ) ) {
 				$this->udev_purge_buffer[] = wp_parse_url( $uri, PHP_URL_PATH );
 			} elseif ( false === $this->udev_purge_buffer ) {
 				$this->udev_purge_buffer = array( wp_parse_url( $uri, PHP_URL_PATH ) );

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -172,7 +172,6 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			$this->cloudflare_enabled = (bool) $cloudflare_state;
 			$this->cloudflare_tier    = ( 'premium' === $cloudflare_state ) ? 'premium' : 'basic';
 
-
 			array_push( $this->cache_exempt, rest_get_url_prefix() );
 
 			$this->hooks();

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -62,7 +62,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		 *
 		 * @var array
 		 */
-		public $cloudflare_support = array( 'BlueHost', 'HostMonster', 'Just_Host' );
+		public $cloudflare_support = array( 'BlueHost' );
 
 		/**
 		 * Whether or not to force a purge.

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1449,6 +1449,12 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				return;
 			}
 
+			$throttle_key = md5( json_encode( $resources ) );
+
+			if ( ! $this->force_purge && true === $this->should_throttle( $throttle_key, __METHOD__ ) ) {
+				return;
+			}
+
 			$hosts    = array( wp_parse_url( home_url(), PHP_URL_HOST ) );
 			$services = ! empty( $override_services ) ? $override_services : self::$udev_api_services;
 


### PR DESCRIPTION
## Proposed changes

**Cloudflare Enabled**
There is an option stored in the DB when a site has had Cloudflare Enabled by our integration. This option is named `endurance_cloudflare_enabled`. We previously had not filtered on this option because the purge endpoint was intended to support multiple services. Currently it only supports Cloudflare so we will filter the requests down to when this is present.

This option has not always been reliable. Sean and Team have prepared updates to make this more reliable and have also updated existing sites that are integrated to contain it.

**Triggers**
We pass the current trigger in the user-agent when we clear NGINX. This has proved useful in the past to help identify triggers that are causing a high qty of requests. Once identified, we can either throttle them differently or add them to our exclude lists if they have no visible impact on a site. 

Since Cloudflare bundles the assets together and purges them on shutdown, we were not sending any trigger because current_action would just be the shutdown event.

This PR adds record keeping for all triggers so that they can be sent over with the bundled payload to the Cloudflare endpoint. This enables us to troubleshoot and become more efficient in the future. This has no functional effect on when purges happen.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

It is additionally worth noting that this branch was created off of cloudflare-optimizations which has now been merged and deployed.

**We should not deploy this until we hear confirmation from Sean Cox or Ron Fulmer that the code changes that have been prepared to make the `endurance_cloudflare_enabled` more reliable have rolled. Rolling this first could put us in the opposite and worse scenario where a site needs to purge and does not.**