### PR TITLE
Update services logic

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1506,7 +1506,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			$services = ! empty( $override_services ) ? $override_services : $this->udev_api_services;
 
 			if ( $services['cf'] && $this->cloudflare_enabled ) {
-				$services['cf'] = $this->cloudflare_enabled;
+				$services['cf'] = $this->cloudflare_tier;
 			}
 
 			wp_remote_post(

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1503,7 +1503,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 			}
 
 			$hosts    = array( wp_parse_url( home_url(), PHP_URL_HOST ) );
-			$services = ! empty( $override_services ) ? $override_services : self::$udev_api_services;
+			$services = ! empty( $override_services ) ? $override_services : $this->udev_api_services;
 
 			if ( $services['cf'] && $this->cloudflare_enabled ) {
 				$services['cf'] = $this->cloudflare_enabled;

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -72,13 +72,6 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		public $cloudflare_tier = 'basic';
 
 		/**
-		 * Brands supporting cloudflare (from mm_brand option).
-		 *
-		 * @var array
-		 */
-		public $cloudflare_support = array( 'BlueHost' );
-
-		/**
 		 * Whether or not to force a purge.
 		 *
 		 * @var bool
@@ -1487,10 +1480,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		protected function udev_cache_purge( $resources = array(), $override_services = array() ) {
 			global $wp_version;
 
-			$brand = get_option( 'mm_brand' );
-
 			if ( $this->use_file_cache()
-				|| ! in_array( $brand, $this->cloudflare_support, true )
 				|| false === $this->cloudflare_enabled
 			) {
 				return;


### PR DESCRIPTION
## Proposed changes

This addresses an issue where the self::$udev_api_services was returning null and silently failing. This would happen right before we made the request to udev api.

This also address an issue where the service['cf'] regressed to a boolean instead of allowing the tier through.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
