### PR TITLE
Remove the check for nonce on page content

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@
 [![License](https://img.shields.io/github/license/bluehost/endurance-page-cache?labelColor=333333&color=666666)](https://raw.githubusercontent.com/bluehost/endurance-page-cache/master/license.txt)
 
 Endurance Page Cache adds basic file-based caching to WordPress, as well as more advanced caching solutions in nginx and Cloudflare. EPC is designed to run best on Endurance systems and your mileage may vary.
+
+## Tagging a new release
+
+- Bump the version number in the header of the `endurance-page-cache.php` file.
+- Push all changes to `master`.
+- Merge all changes to `production`.
+- Create a release on GitHub for the new version.
+- Log into DigitalOcean and update the [`mu-plugins.json`](https://cdn.hiive.space/bluehost/mu-plugins.json) file on the CDN to reflect the new version number.

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -609,7 +609,7 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		public function write( $page ) {
 			$base = wp_parse_url( trailingslashit( get_option( 'home' ) ), PHP_URL_PATH );
 
-			if ( false === strpos( $page, 'nonce' ) && ! empty( $page ) ) {
+			if ( ! empty( $page ) ) {
 				$path = WP_CONTENT_DIR . '/endurance-page-cache' . str_replace( get_option( 'home' ), '', esc_url( $_SERVER['REQUEST_URI'] ) );
 				$path = str_replace( '/endurance-page-cache' . $base, '/endurance-page-cache/', $path );
 				$path = str_replace( '//', '/', $path );

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Endurance Page Cache
  * Description: This cache plugin is primarily for cache purging of the additional layers of cache that may be available on your hosting account.
- * Version: 2.0.7
+ * Version: 2.0.8
  * Author: Mike Hansen
  * Author URI: https://www.mikehansen.me/
  * License: GPLv2 or later
@@ -27,7 +27,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'EPC_VERSION', '2.0.7' );
+define( 'EPC_VERSION', '2.0.8' );
 
 if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 


### PR DESCRIPTION
Remove the check for the word `nonce` within the page content. 

With nonces valid for 24 hours and new ones created every 12 hours, it should not be impacted by our short cache window and will allow caching of more pages. 