### PR TITLE
Schedule Option Handler Purges

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -155,11 +155,19 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 		);
 
 		/**
+		 * The hook name for scheduling a cache purge event.
+		 *
+		 * @var string
+		 */
+		public $epc_scheduled_purge_all_hook = 'epc_scheduled_purge_all';
+
+		/**
 		 * Endurance_Page_Cache constructor.
 		 */
 		public function __construct() {
 
 			if ( isset( $_GET['doing_wp_cron'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				add_action( $this->epc_scheduled_purge_all_hook, array( __CLASS__, 'scheduled_purge_all' ) );
 				return;
 			}
 
@@ -512,10 +520,31 @@ if ( ! class_exists( 'Endurance_Page_Cache' ) ) {
 				}
 			}
 
-			$this->add_trigger( 'option_update_' . $option );
-			$this->purge_all();
-
+			$this->add_trigger( 'option_handler' );
+			// Schedule a purge if not already scheduled.
+			$this->schedule_purge_all();
 			return true;
+		}
+
+		/**
+		 * Schedules a single event for purging the cache.
+		 *
+		 * @return void
+		 */
+		public function schedule_purge_all() {
+			if ( ! wp_next_scheduled( $this->epc_scheduled_purge_all_hook ) ) {
+				wp_schedule_single_event( time() + 60, $this->epc_scheduled_purge_all_hook );
+			}
+		}
+
+		/**
+		 * Static cron job handler to execute a purge all.
+		 */
+		public static function scheduled_purge_all() {
+			$instance = self::get_instance();
+			if ( $instance ) {
+				$instance->purge_all();
+			}
 		}
 
 		/**
@@ -1660,6 +1689,21 @@ HTACCESS;
 			if ( ! empty( $this->udev_purge_buffer ) || is_array( $this->udev_purge_buffer ) ) {
 				$this->udev_cache_purge( $this->udev_purge_buffer );
 			}
+		}
+
+		/**
+		 * Retrieve the singleton instance of the class.
+		 *
+		 * @return Endurance_Page_Cache
+		 */
+		public static function get_instance() {
+			static $instance = null;
+
+			if ( null === $instance ) {
+				$instance = new self();
+			}
+
+			return $instance;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

Story: https://jira.newfold.com/browse/PRESS7-124

In cases of option updates, the option handler was processing a large number of concurrent updates, which overloaded the server with requests because the throttle could not intervene quickly enough. This PR introduces a WP Cron event that is scheduled whenever an option update occurs. The event triggers a single cache purge 60 seconds later, preventing multiple requests from overwhelming the server at once.

https://github.com/user-attachments/assets/64bc8bb1-ab8b-4070-9f4e-6a9d5ab2485b

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
