### PR TITLE
PRESS0-5047: Read the cache level fresh when reconciling .htaccess

### DIFF
--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1982,11 +1982,21 @@ HTACCESS;
 			if ( ! file_exists( $path ) && ! @touch( $path ) ) { return;
 			}
 
+			// $this->cache_level is read once, in the constructor. Anything that
+			// writes the option later in the same request (a brand plugin
+			// switching us off, for one) would otherwise not be seen until the
+			// next request, and the rules below would be built from the value
+			// the request started with. Re-read it here, and keep the property
+			// in step because use_file_cache() and the rule builders go through
+			// it too. The clamp mirrors get_cache_level() without its write,
+			// which would re-enter this method through update_option.
+			$level             = min( 3, absint( get_option( 'endurance_cache_level', 2 ) ) );
+			$this->cache_level = $level;
+
 			// Decide if we *should* have any EPC rules at all (holistic)
-			$level             = (int) get_option( 'endurance_cache_level', 0 );
 			$skip_404          = (bool) get_option( 'epc_skip_404_handling', 0 );
 			$page_on           = ( $this->is_enabled( 'page' ) && $this->use_file_cache() );
-			$browser_on        = ( $this->is_enabled( 'browser' ) && $this->cache_level >= 1 );
+			$browser_on        = ( $this->is_enabled( 'browser' ) && $level >= 1 );
 			$should_have_rules = ( $page_on || $browser_on || $skip_404 );
 
 			// Preferred path: hand the rules off to wp-module-htaccess so a

--- a/endurance-page-cache.php
+++ b/endurance-page-cache.php
@@ -1984,15 +1984,41 @@ HTACCESS;
 
 			// $this->cache_level is read once, in the constructor. Anything that
 			// writes the option later in the same request (a brand plugin
-			// switching us off, for one) would otherwise not be seen until the
-			// next request, and the rules below would be built from the value
-			// the request started with. Re-read it here, and keep the property
-			// in step because use_file_cache() and the rule builders go through
-			// it too. The clamp mirrors get_cache_level() without its write,
-			// which would re-enter this method through update_option.
-			$level             = min( 3, absint( get_option( 'endurance_cache_level', 2 ) ) );
-			$this->cache_level = $level;
+			// switching us off, for one) would otherwise not be seen here, and
+			// the rules would be built from the value the request started with.
+			//
+			// The property is what use_file_cache() and the rule builders read,
+			// so point it at what is stored for the length of this reconcile and
+			// put it back afterwards. Restoring is the point: cache_level_change()
+			// runs on pre_update_option, so it sets the property to the incoming
+			// level before the option is written, and its own
+			// update_level_expirations() call reconciles from in there. That
+			// nested pass still reads the old stored value, and keeping it would
+			// leave the property behind for config_nginx() and purge_all().
+			//
+			// The clamp mirrors get_cache_level() without its write, which would
+			// re-enter this method through update_option.
+			$previous_cache_level = $this->cache_level;
+			$this->cache_level    = min( 3, absint( get_option( 'endurance_cache_level', 2 ) ) );
 
+			try {
+				$this->nfd_reconcile_epc_htaccess_rules( $path, $this->cache_level );
+			} finally {
+				$this->cache_level = $previous_cache_level;
+			}
+		}
+
+		/**
+		 * Bring the EPC block in .htaccess into line with the given cache level.
+		 *
+		 * Split out of nfd_reconcile_epc_htaccess() so that method can restore
+		 * $this->cache_level on every exit path.
+		 *
+		 * @param string $path  Path to the .htaccess file.
+		 * @param int    $level Cache level the rules should be built from.
+		 * @return void
+		 */
+		private function nfd_reconcile_epc_htaccess_rules( $path, $level ) {
 			// Decide if we *should* have any EPC rules at all (holistic)
 			$skip_404          = (bool) get_option( 'epc_skip_404_handling', 0 );
 			$page_on           = ( $this->is_enabled( 'page' ) && $this->use_file_cache() );


### PR DESCRIPTION
`$this->cache_level` is set once in the constructor, so a cache level written later in the same request wasn't visible to the reconcile that the option change itself triggers. The block got rebuilt from the level the request started with, and the new value only took effect on the following request.

`nfd_reconcile_epc_htaccess` now reads the option at the top and keeps the property in step, since `use_file_cache()` and the rule builders read it too. `$level` was already being read there and then ignored; it now decides the browser rules. The clamp mirrors `get_cache_level()` without its `update_option`, which would re-enter the reconcile.

Ticket: [PRESS0-5047](https://newfold.atlassian.net/browse/PRESS0-5047)
Paired with: [newfold-labs/wp-module-performance#634](https://github.com/newfold-labs/wp-module-performance/pull/634), which stops the brand plugin from deleting `endurance_cache_level` (EPC defaults it to 2). Each side is safe to merge on its own.